### PR TITLE
Fix villagers losing profession immediately after `/villager spawn`.

### DIFF
--- a/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SaveFileCommand.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SaveFileCommand.java
@@ -62,8 +62,8 @@ public class SaveFileCommand extends VillagerSpecificAbstractCommand {
         String name = customName != null ? PlainTextComponentSerializer.plainText().serialize(customName) : null;
 
         config.set("name", name);
-        config.set("biome", villager.getVillagerType().toString());
-        config.set("profession", villager.getProfession().toString());
+        config.set("biome", villager.getVillagerType().getKey().getKey());
+        config.set("profession", villager.getProfession().getKey().getKey());
         config.set("level", villager.getVillagerLevel());
         config.set("static", plugin.getVillagerMeta().STATIC_MERCHANTS.contains(villager.getUniqueId().toString()));
 

--- a/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnCommand.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnCommand.java
@@ -90,12 +90,11 @@ public class SpawnCommand extends AbstractCommand implements TabCompleter {
             villager.setVillagerLevel(level);
         }
 
-        String description = villager.getVillagerType().getKey().getKey() +
-                " villager, profession " + villager.getProfession().getKey().getKey() +
-                ", level " + villager.getVillagerLevel();
+        String description = VillagerHelper.getDescription(villager);
 
-        plugin.getLogger().info(player.getName() + " spawned " + description +
-                " at " + loc.getBlockX() + ", " + loc.getBlockY() + ", " + loc.getBlockZ());
+        plugin.getLogger().info(String.format("%s spawned %s at %d, %d, %d",
+                player.getName(), description, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
+
         player.sendMessage(Component.text("Spawned " + description + ".", NamedTextColor.DARK_AQUA));
         return true;
     }

--- a/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnCommand.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnCommand.java
@@ -64,7 +64,7 @@ public class SpawnCommand extends AbstractCommand implements TabCompleter {
             }
         }
 
-        Integer level = null;
+        int level = 5;
         if (args.length == 3) {
             try {
                 level = Integer.parseInt(args[2]);
@@ -86,8 +86,12 @@ public class SpawnCommand extends AbstractCommand implements TabCompleter {
         if (profession != null) {
             villager.setProfession(profession);
         }
-        if (level != null) {
-            villager.setVillagerLevel(level);
+        villager.setVillagerLevel(level);
+
+        // A villager's profession will reset if they do not have a job site, have 0 XP, and level <= 1.
+        // To workaround this, we set XP to a non-zero value if the level is 1.
+        if (level == 1) {
+            villager.setVillagerExperience(1);
         }
 
         String description = VillagerHelper.getDescription(villager);

--- a/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnCommand.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnCommand.java
@@ -90,8 +90,8 @@ public class SpawnCommand extends AbstractCommand implements TabCompleter {
             villager.setVillagerLevel(level);
         }
 
-        String description = villager.getVillagerType().toString().toLowerCase() +
-                " villager, profession " + villager.getProfession().toString().toLowerCase() +
+        String description = villager.getVillagerType().getKey().getKey() +
+                " villager, profession " + villager.getProfession().getKey().getKey() +
                 ", level " + villager.getVillagerLevel();
 
         plugin.getLogger().info(player.getName() + " spawned " + description +

--- a/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnFileCommand.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnFileCommand.java
@@ -132,7 +132,14 @@ public class SpawnFileCommand extends AbstractCommand {
             return false;
         }
 
-        villager.setVillagerLevel(config.getInt("level"));
+        int level = config.getInt("level", 5);
+        villager.setVillagerLevel(level);
+
+        // A villager's profession will reset if they do not have a job site, have 0 XP, and level <= 1.
+        // To workaround this, we set XP to a non-zero value if the level is 1.
+        if (level == 1) {
+            villager.setVillagerExperience(1);
+        }
 
         if (config.getBoolean("static")) {
             plugin.getVillagerMeta().STATIC_MERCHANTS.add(villager.getUniqueId().toString());

--- a/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnFileCommand.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnFileCommand.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import io.github.redwallhp.villagerutils.helpers.VillagerHelper;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
@@ -166,9 +168,7 @@ public class SpawnFileCommand extends AbstractCommand {
         }
         villager.setRecipes(recipes);
 
-        String description = villager.getVillagerType().getKey().getKey() +
-                " villager, profession " + villager.getProfession().getKey().getKey() +
-                ", level " + villager.getVillagerLevel();
+        String description = VillagerHelper.getDescription(villager);
 
         plugin.getLogger().info(String.format("%s spawned %s at %d, %d, %d",
                 player.getName(), description, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));

--- a/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnFileCommand.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/commands/villager/SpawnFileCommand.java
@@ -166,8 +166,8 @@ public class SpawnFileCommand extends AbstractCommand {
         }
         villager.setRecipes(recipes);
 
-        String description = villager.getVillagerType().toString().toLowerCase() +
-                " villager, profession " + villager.getProfession().toString().toLowerCase() +
+        String description = villager.getVillagerType().getKey().getKey() +
+                " villager, profession " + villager.getProfession().getKey().getKey() +
                 ", level " + villager.getVillagerLevel();
 
         plugin.getLogger().info(String.format("%s spawned %s at %d, %d, %d",

--- a/src/main/java/io/github/redwallhp/villagerutils/helpers/VillagerHelper.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/helpers/VillagerHelper.java
@@ -70,7 +70,7 @@ public class VillagerHelper {
      */
     public static List<String> getProfessionNames() {
         return Registry.VILLAGER_PROFESSION.stream()
-                .map(p -> p.key().toString().replace("minecraft:", ""))
+                .map(p -> p.getKey().getKey())
                 .sorted()
                 .collect(Collectors.toList());
     }
@@ -82,7 +82,7 @@ public class VillagerHelper {
      */
     public static List<String> getVillagerTypeNames() {
         return Registry.VILLAGER_TYPE.stream()
-                .map(t -> t.key().toString().replace("minecraft:", ""))
+                .map(t -> t.getKey().getKey())
                 .sorted()
                 .collect(Collectors.toList());
     }

--- a/src/main/java/io/github/redwallhp/villagerutils/helpers/VillagerHelper.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/helpers/VillagerHelper.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Helper methods for working with Villagers
@@ -85,5 +86,16 @@ public class VillagerHelper {
                 .map(t -> t.getKey().getKey())
                 .sorted()
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Return a human readable description of a villager.
+     *
+     * @return String description including villager type, profession, and level.
+     */
+    public static @NotNull String getDescription(Villager villager) {
+        return villager.getVillagerType().getKey().getKey() +
+                " villager, profession " + villager.getProfession().getKey().getKey() +
+                ", level " + villager.getVillagerLevel();
     }
 }

--- a/src/main/java/io/github/redwallhp/villagerutils/listeners/VillagerLogger.java
+++ b/src/main/java/io/github/redwallhp/villagerutils/listeners/VillagerLogger.java
@@ -51,8 +51,8 @@ public class VillagerLogger implements Listener {
         }
 
         if (villager instanceof Villager v) {
-            sb.append(String.format("Profession: %s | ", v.getProfession()));
-            sb.append(String.format("Biome: %s | ", v.getVillagerType()));
+            sb.append(String.format("Profession: %s | ", v.getProfession().getKey().getKey()));
+            sb.append(String.format("Biome: %s | ", v.getVillagerType().getKey().getKey()));
             sb.append(String.format("Level: %d | ", v.getVillagerLevel()));
             sb.append(String.format("Experience: %d | ", v.getVillagerExperience()));
         }


### PR DESCRIPTION
A villager's profession will reset if they do not have a job site, have 0 XP, and level <= 1.

To avoid this scenario, we will default level to 5. If level 1 is explicitly requested, we employ a workaround setting XP to 1.

Note this branch is built on top of drtmv:fix-enum-strings. If this is accepted, #4 can be closed.